### PR TITLE
Add Dockerfile for Containerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:lts-alpine3.19 AS base
+
+FROM base as deps
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+
+RUN npm install --omit=dev
+
+FROM base as runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+RUN addgroup --system --gid 1001 nodejs && \
+adduser --system --uid 1001 expressjs
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+USER expressjs
+
+EXPOSE 3000
+ENV APP_PORT=3000
+
+CMD ["app.js"]


### PR DESCRIPTION
TLDR; Dockerfile for containerization that'll later be used in https://github.com/porosub/sysadmin-workshop

Added a Dockerfile for containerization. It'll be used later in the sysadmin workshop to demonstrate how to deliver backend services using containerization with Podman, provisioned via Ansible. The Dockerfile was tested before I opened this PR. Here's a screenshot of it running with podman cli (aliased as docker).

![image](https://github.com/user-attachments/assets/26eb2525-16da-48f2-9eab-ae36d5728f0a)

Changes made:
[+] added Dockerfile